### PR TITLE
Enabling [Disabled(typeof(TypeName))] overload

### DIFF
--- a/src/Microsoft.NET.Sdk.Functions.Generator/MethodInfoExtensions.cs
+++ b/src/Microsoft.NET.Sdk.Functions.Generator/MethodInfoExtensions.cs
@@ -169,11 +169,6 @@ namespace MakeFunctionJson
                 error = "'%' expressions are not supported for 'Disable'. Use 'Disable(\"settingName\") instead of 'Disable(\"%settingName%\")'";
                 return true;
             }
-            else if (disabled is Type)
-            {
-                error = "the constructor 'DisableAttribute(Type)' is not supported.";
-                return true;
-            }
             else
             {
                 return false;


### PR DESCRIPTION
This validation was outdated. Tested locally using Microsoft.NET.Sdk.Functions (3.0.2) and Microsoft.Azure.WebJobs (3.0.22).

```csharp
        [Disable(typeof(ValidadorDisable))]
        [FunctionName(FunctionName)]
        public async Task Run([TimerTrigger(CronJob)] TimerInfo timer, ILogger log)
        {
            throw new NotImplementedException();
        }
```

```csharp
 public class ValidadorDisable
    {
        public bool IsDisabled(MethodInfo method)
        {
            var functionName = method.GetCustomAttributes(true).OfType<FunctionNameAttribute>().FirstOrDefault().Name;
            return Configuration.Get.FunctionConfiguration.DisabledFunctions[functionName];
        }
    }
```